### PR TITLE
Update Gemfile.lock - nokogiri security vuln patch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
       typhoeus (~> 0.7)
     html-pipeline (2.11.0)
       activesupport (>= 2)
-      nokogiri (>= 1.4)
+      nokogiri (>= 1.12.5)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     jekyll (3.1.6)


### PR DESCRIPTION
updating gems to pull newer nokogiri from 1.4 to 1.12.15 or higher due to potential security vulnerability